### PR TITLE
#110 improve code quality/mongoqueryengine/queryengine

### DIFF
--- a/pkg/queryengines/mongoqueryengine/queryengine.go
+++ b/pkg/queryengines/mongoqueryengine/queryengine.go
@@ -29,7 +29,7 @@ func InitMongoQueryEngine() *MongoQueryEngine {
 	}
 }
 
-func (mqw *MongoQueryEngine) runFindOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runFindOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result := db.Collection(queryType.CollectionName).FindOne(context.Background(), queryType.Args[0])
 	if result.Err() != nil {
 		return nil, result.Err()
@@ -41,7 +41,7 @@ func (mqw *MongoQueryEngine) runFindOneQuery(db *mongo.Database, queryType *mong
 	}, nil
 }
 
-func (mqw *MongoQueryEngine) runFindQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runFindQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	collection := db.Collection(queryType.CollectionName)
 	opts := &options.FindOptions{Limit: queryType.Limit, Skip: queryType.Skip, Sort: queryType.Sort}
 	if len(queryType.Args) > 1 {
@@ -62,7 +62,7 @@ func (mqw *MongoQueryEngine) runFindQuery(db *mongo.Database, queryType *mongout
 
 }
 
-func (mqw *MongoQueryEngine) runInsertOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runInsertOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result, err := db.Collection(queryType.CollectionName).
 		InsertOne(context.Background(), queryType.Args[0])
 	if err != nil {
@@ -79,7 +79,7 @@ func (mqw *MongoQueryEngine) runInsertOneQuery(db *mongo.Database, queryType *mo
 
 }
 
-func (mqw *MongoQueryEngine) runInsertManyQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runInsertManyQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result, err := db.Collection(queryType.CollectionName).
 		InsertMany(context.Background(), queryType.Args[0].(bson.A))
 	if err != nil {
@@ -96,7 +96,7 @@ func (mqw *MongoQueryEngine) runInsertManyQuery(db *mongo.Database, queryType *m
 
 }
 
-func (mqw *MongoQueryEngine) runDeleteOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runDeleteOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result, err := db.Collection(queryType.CollectionName).
 		DeleteOne(context.Background(), queryType.Args[0])
 	if err != nil {
@@ -113,7 +113,7 @@ func (mqw *MongoQueryEngine) runDeleteOneQuery(db *mongo.Database, queryType *mo
 
 }
 
-func (mqw *MongoQueryEngine) runDeleteManyQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runDeleteManyQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result, err := db.Collection(queryType.CollectionName).
 		DeleteMany(context.Background(), queryType.Args[0].(bson.D))
 	if err != nil {
@@ -130,7 +130,7 @@ func (mqw *MongoQueryEngine) runDeleteManyQuery(db *mongo.Database, queryType *m
 
 }
 
-func (mqw *MongoQueryEngine) runUpdateOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runUpdateOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result, err := db.Collection(queryType.CollectionName).
 		UpdateOne(context.Background(), queryType.Args[0], queryType.Args[1])
 	if err != nil {
@@ -168,7 +168,7 @@ func (mwq *MongoQueryEngine) runUpdateManyQuery(db *mongo.Database, queryType *m
 
 }
 
-func (mqw *MongoQueryEngine) runReplaceOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runReplaceOneQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result, err := db.Collection(queryType.CollectionName).
 		ReplaceOne(context.Background(), queryType.Args[0], queryType.Args[1])
 	if err != nil {
@@ -187,7 +187,7 @@ func (mqw *MongoQueryEngine) runReplaceOneQuery(db *mongo.Database, queryType *m
 
 }
 
-func (mqw *MongoQueryEngine) runCMDQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runCMDQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	result := db.RunCommand(context.Background(), queryType.Args[0])
 	if result.Err() != nil {
 		return nil, result.Err()
@@ -202,7 +202,7 @@ func (mqw *MongoQueryEngine) runCMDQuery(db *mongo.Database, queryType *mongouti
 
 }
 
-func (mqw *MongoQueryEngine) runGetIndexesQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runGetIndexesQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	cursor, err := db.RunCommandCursor(context.Background(), bson.M{
 		"listIndexes": queryType.CollectionName,
 	})
@@ -219,7 +219,7 @@ func (mqw *MongoQueryEngine) runGetIndexesQuery(db *mongo.Database, queryType *m
 
 }
 
-func (mqw *MongoQueryEngine) runListCollectionsQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runListCollectionsQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	list, err := db.ListCollectionNames(context.Background(), queryType.Args[0])
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (mqw *MongoQueryEngine) runListCollectionsQuery(db *mongo.Database, queryTy
 
 }
 
-func (mqw *MongoQueryEngine) runCountQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runCountQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	opts := &options.CountOptions{Limit: queryType.Limit, Skip: queryType.Skip}
 	count, err := db.Collection(queryType.CollectionName).
 		CountDocuments(context.Background(), queryType.Args[0], opts)
@@ -252,7 +252,7 @@ func (mqw *MongoQueryEngine) runCountQuery(db *mongo.Database, queryType *mongou
 	}, nil
 }
 
-func (mqw *MongoQueryEngine) runAggregateQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runAggregateQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	cursor, err := db.Collection(queryType.CollectionName).
 		Aggregate(context.Background(), queryType.Args[0])
 	if err != nil {
@@ -267,7 +267,7 @@ func (mqw *MongoQueryEngine) runAggregateQuery(db *mongo.Database, queryType *mo
 	}, nil
 }
 
-func (mqw *MongoQueryEngine) runDropQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runDropQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	err := db.Collection(queryType.CollectionName).Drop(context.Background())
 	if err != nil {
 		return nil, err
@@ -277,7 +277,7 @@ func (mqw *MongoQueryEngine) runDropQuery(db *mongo.Database, queryType *mongout
 	}, nil
 }
 
-func (mqw *MongoQueryEngine) runCreateIndexQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runCreateIndexQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	opts := options.Index()
 	if len(queryType.Args) > 1 {
 		if d, ok := queryType.Args[1].(bson.D); ok {
@@ -303,7 +303,7 @@ func (mqw *MongoQueryEngine) runCreateIndexQuery(db *mongo.Database, queryType *
 	}, nil
 }
 
-func (mqw *MongoQueryEngine) runDropIndexQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
+func (mqe *MongoQueryEngine) runDropIndexQuery(db *mongo.Database, queryType *mongoutils.MongoQuery) (map[string]interface{}, error) {
 	indexName, ok := queryType.Args[0].(string)
 	if !ok {
 		return nil, errors.New("invalid query")

--- a/pkg/queryengines/mongoqueryengine/queryengine.go
+++ b/pkg/queryengines/mongoqueryengine/queryengine.go
@@ -355,15 +355,16 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		return nil, errors.New("not allowed run this query")
 	}
 
-	if queryType.QueryType == mongoutils.QUERY_FINDONE {
+	switch queryType.QueryType {
+
+	case mongoutils.QUERY_FINDONE:
 		result, err := mqe.runFindOneQuery(db, queryType)
 		if err != nil {
 			return nil, err
 		}
 
 		return result, nil
-
-	} else if queryType.QueryType == mongoutils.QUERY_FIND {
+	case mongoutils.QUERY_FIND:
 		result, err := mqe.runFindQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -374,7 +375,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 
 		return result, nil
 
-	} else if queryType.QueryType == mongoutils.QUERY_INSERTONE {
+	case mongoutils.QUERY_INSERTONE:
 		result, err := mqe.runInsertOneQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -385,8 +386,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return result, nil
-
-	} else if queryType.QueryType == mongoutils.QUERY_INSERT {
+	case mongoutils.QUERY_INSERT:
 		result, err := mqe.runInsertManyQuery(db, queryType)
 
 		if err != nil {
@@ -398,7 +398,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 
 		return result, nil
 
-	} else if queryType.QueryType == mongoutils.QUERY_DELETEONE {
+	case mongoutils.QUERY_DELETEONE:
 		result, err := mqe.runDeleteOneQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -409,7 +409,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 
 		return result, nil
 
-	} else if queryType.QueryType == mongoutils.QUERY_DELETEMANY {
+	case mongoutils.QUERY_DELETEMANY:
 		result, err := mqe.runDeleteManyQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -420,8 +420,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return result, nil
-
-	} else if queryType.QueryType == mongoutils.QUERY_UPDATEONE {
+	case mongoutils.QUERY_UPDATEONE:
 		result, err := mqe.runUpdateOneQuery(db, queryType)
 
 		if err != nil {
@@ -431,7 +430,8 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 			config.CreateLogFn(query)
 		}
 		return result, nil
-	} else if queryType.QueryType == mongoutils.QUERY_UPDATEMANY {
+
+	case mongoutils.QUERY_UPDATEMANY:
 		result, err := mqe.runUpdateManyQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -441,7 +441,8 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return result, nil
-	} else if queryType.QueryType == mongoutils.QUERY_REPLACEONE {
+
+	case mongoutils.QUERY_REPLACEONE:
 		result, err := mqe.runReplaceOneQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -451,7 +452,8 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return result, nil
-	} else if queryType.QueryType == mongoutils.QUERY_RUNCMD {
+
+	case mongoutils.QUERY_RUNCMD:
 		result, err := mqe.runCMDQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -462,8 +464,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return result, nil
-
-	} else if queryType.QueryType == mongoutils.QUERY_GETINDEXES {
+	case mongoutils.QUERY_GETINDEXES:
 		results, err := mqe.runGetIndexesQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -474,7 +475,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return results, nil
-	} else if queryType.QueryType == mongoutils.QUERY_LISTCOLLECTIONS {
+	case mongoutils.QUERY_LISTCOLLECTIONS:
 		list, err := mqe.runListCollectionsQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -484,8 +485,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return list, nil
-
-	} else if queryType.QueryType == mongoutils.QUERY_COUNT {
+	case mongoutils.QUERY_COUNT:
 
 		count, err := mqe.runCountQuery(db, queryType)
 		if err != nil {
@@ -496,8 +496,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return count, nil
-
-	} else if queryType.QueryType == mongoutils.QUERY_AGGREGATE {
+	case mongoutils.QUERY_AGGREGATE:
 		cursor, err := mqe.runAggregateQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -507,7 +506,8 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 		}
 
 		return cursor, nil
-	} else if queryType.QueryType == mongoutils.QUERY_DROP {
+
+	case mongoutils.QUERY_DROP:
 		result, err := mqe.runDropQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -516,7 +516,7 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 			config.CreateLogFn(query)
 		}
 		return result, nil
-	} else if queryType.QueryType == mongoutils.QUERY_CREATEINDEX {
+	case mongoutils.QUERY_CREATEINDEX:
 		index, err := mqe.runCreateIndexQuery(db, queryType)
 		if err != nil {
 			return nil, err
@@ -527,15 +527,18 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 
 		return index, nil
 
-	} else if queryType.QueryType == mongoutils.QUERY_DROPINDEX {
+	case mongoutils.QUERY_DROPINDEX:
 		result, err := mqe.runDropIndexQuery(db, queryType)
 
 		if config.CreateLogFn != nil {
 			config.CreateLogFn(query)
 		}
 		return result, err
+
+	default:
+		return nil, errors.New("unknown query")
 	}
-	return nil, errors.New("unknown query")
+
 }
 
 func (mqe *MongoQueryEngine) TestConnection(dbConn *models.DBConnection, config *models.QueryConfig) error {

--- a/pkg/queryengines/mongoqueryengine/queryengine.go
+++ b/pkg/queryengines/mongoqueryengine/queryengine.go
@@ -47,7 +47,7 @@ func (mqw *MongoQueryEngine) runFindQuery(db *mongo.Database, queryType *mongout
 	if len(queryType.Args) > 1 {
 		opts.SetProjection(queryType.Args[1])
 	}
-	//TODO could consider using context.WithTimeout here
+
 	cursor, err := collection.
 		Find(context.Background(), queryType.Args[0], opts)
 	if err != nil {
@@ -363,6 +363,9 @@ func (mqe *MongoQueryEngine) RunQuery(dbConn *models.DBConnection, query string,
 			return nil, err
 		}
 
+		if config.CreateLogFn != nil {
+			config.CreateLogFn(query)
+		}
 		return result, nil
 	case mongoutils.QUERY_FIND:
 		result, err := mqe.runFindQuery(db, queryType)


### PR DESCRIPTION
Relating to issue #110 

Refactored code to switch statements and smaller functions that manage each query result and handle errors. 
This should be both easier to manage as well as add to in the future.

I tested all the function implementations after running 'wails dev' and using the linux gui and it worked the same as it did when I ran against the main branch. 

Please let me know if you have any suggested changes. If you're okay with the changes I'll go ahead and work on the next issue on codefactor.