### PR TITLE
refactor: jsontable, showdata, sidebar and global.css

### DIFF
--- a/frontend/src/components/dbfragments/jsontable/jsontable.tsx
+++ b/frontend/src/components/dbfragments/jsontable/jsontable.tsx
@@ -107,10 +107,11 @@ const JsonTable = ({ queryData, dbConnection, mName, isInteractive, showHeader, 
         rows,
         prepareRow,
         state,
-    } = useTable<any>({
+    } = useTable({
         columns,
         data,
         defaultColumn,
+        initialState: { selectedRowIds : {}},
         ...{ editingCellIndex, startEditing, onSaveCell }
     }, useRowSelect, hooks => {
         if (isInteractive && isEditing)
@@ -127,7 +128,7 @@ const JsonTable = ({ queryData, dbConnection, mName, isInteractive, showHeader, 
 
     const newState: any = state // temporary typescript hack
     const selectedRows: number[] = Object.keys(newState.selectedRowIds).map(x => parseInt(x))
-    const selectedUnderscoreIDs = rows.filter((_, i) => selectedRows.includes(i)).map(x => x.original['_id']).filter(x => x)
+    const selectedUnderscoreIDs = rows.filter((_, i) => selectedRows.includes(i)).map(x => (x.original as any)['_id']).filter(x => x)
 
     const deleteRows = async () => {
         if (selectedUnderscoreIDs.length > 0) {

--- a/frontend/src/components/dbfragments/jsontable/jsontable.tsx
+++ b/frontend/src/components/dbfragments/jsontable/jsontable.tsx
@@ -62,7 +62,7 @@ const JsonTable = ({ queryData, dbConnection, mName, isInteractive, showHeader, 
 
     const changeFilter = () => {
         let filter: string[] | undefined = undefined
-        let filterText = filterRef.current!.value.trim()
+        const filterText = filterRef.current!.value.trim()
         if (filterText !== '' && filterText.startsWith("{") && filterText.endsWith("}")) {
             filter = [filterText]
         }
@@ -74,7 +74,7 @@ const JsonTable = ({ queryData, dbConnection, mName, isInteractive, showHeader, 
             return
         }
         let sort: string[] | undefined = undefined
-        let sortText = sortRef.current!.value.trim()
+        const sortText = sortRef.current!.value.trim()
         if (sortText !== '' && sortText.startsWith("{") && sortText.endsWith("}")) {
             sort = [sortText]
         }

--- a/frontend/src/components/dbfragments/showdata.tsx
+++ b/frontend/src/components/dbfragments/showdata.tsx
@@ -11,11 +11,7 @@ import JsonTable from './jsontable/jsontable'
 import { getDBDataInDataModel, selectIsFetchingQueryData, selectQueryData } from '../../redux/dataModelSlice'
 import TabContext from '../layouts/tabcontext'
 
-type DBShowDataPropType = {
-
-}
-
-const DBShowDataFragment = (_: DBShowDataPropType) => {
+const DBShowDataFragment = () => {
 
     const dispatch = useAppDispatch()
 

--- a/frontend/src/components/dbfragments/table/table.tsx
+++ b/frontend/src/components/dbfragments/table/table.tsx
@@ -100,10 +100,11 @@ const Table = ({ queryData, dbConnection, mSchema, mName, isInteractive, showHea
         rows,
         prepareRow,
         state,
-    } = useTable<any>({
+    } = useTable({
         columns,
         data,
         defaultColumn,
+        initialState: { selectedRowIds: {}},
         ...{ editCell, resetEditCell, onSaveCell }
     },
         useRowSelect,
@@ -121,12 +122,10 @@ const Table = ({ queryData, dbConnection, mSchema, mName, isInteractive, showHea
         }
     )
 
-    const newState: any = state // temporary typescript hack
-    const selectedRowIds: any = newState.selectedRowIds
-    const selectedRows: number[] = Object.keys(selectedRowIds).map(x => parseInt(x))
+    const selectedRows: number[] = Object.keys(state.selectedRowIds).map(x => parseInt(x))
     const selectedIDs = dbConnection.type === DBConnType.POSTGRES ?
-        rows.filter((_, i) => selectedRows.includes(i)).map(x => x.original['0']).filter(x => x)
-        : rows.filter((_, i) => selectedRows.includes(i)).map(x => queryData.pkeys!.map((pkey) => ({ [pkey]: x.original[queryData.columns.findIndex(x => x === pkey)] }))).map(x => x.reduce(((r, c) => Object.assign(r, c)), {})).map(x => JSON.stringify(x))
+        rows.filter((_, i) => selectedRows.includes(i)).map(x => (x.original as any)['0']).filter(x => x)
+        : rows.filter((_, i) => selectedRows.includes(i)).map(x => queryData.pkeys!.map((pkey) => ({ [pkey]: (x.original as any)[queryData.columns.findIndex(x => x === pkey)] }))).map(x => x.reduce(((r, c) => Object.assign(r, c)), {})).map(x => JSON.stringify(x))
 
     const deleteRows = async () => {
         if (dbConnection.type === DBConnType.MYSQL && queryData.pkeys?.length === 0) {

--- a/frontend/src/components/layouts/sidebar.tsx
+++ b/frontend/src/components/layouts/sidebar.tsx
@@ -16,17 +16,19 @@ enum SidebarViewType {
     SETTINGS = "SETTINGS" // Used to show elements of settings screen
 }
 
-type SidebarPropType = {}
+// type SidebarPropType = {}
 
-const Sidebar = (_: SidebarPropType) => {
+const Sidebar = () => {
 
     const location = useLocation()
-    const { queryId } = useParams()
-    const [searchParams] = useSearchParams()
-    const mschema = searchParams.get("mschema")
-    const mname = searchParams.get("mname")
 
-    let sidebarView: SidebarViewType =
+    // Commenting them as they might be neded in future
+    // const { queryId } = useParams()
+    // const [searchParams] = useSearchParams()
+    // const mschema = searchParams.get("mschema")
+    // const mname = searchParams.get("mname")
+
+    const sidebarView: SidebarViewType =
         (location.pathname.startsWith("/db")) ?
             SidebarViewType.DATABASE : (location.pathname.startsWith("/settings")) ? SidebarViewType.SETTINGS : SidebarViewType.HOME
 

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -110,7 +110,6 @@ code {
   display: flex;
   justify-content: center;
   align-items: center;
-  display: inline-flex;
   border-radius: 100px;
 }
 

--- a/frontend/src/types/react-table-config.d.ts
+++ b/frontend/src/types/react-table-config.d.ts
@@ -1,0 +1,130 @@
+import {
+  UseColumnOrderInstanceProps,
+  UseColumnOrderState,
+  UseExpandedHooks,
+  UseExpandedInstanceProps,
+  UseExpandedOptions,
+  UseExpandedRowProps,
+  UseExpandedState,
+  UseFiltersColumnOptions,
+  UseFiltersColumnProps,
+  UseFiltersInstanceProps,
+  UseFiltersOptions,
+  UseFiltersState,
+  UseGlobalFiltersColumnOptions,
+  UseGlobalFiltersInstanceProps,
+  UseGlobalFiltersOptions,
+  UseGlobalFiltersState,
+  UseGroupByCellProps,
+  UseGroupByColumnOptions,
+  UseGroupByColumnProps,
+  UseGroupByHooks,
+  UseGroupByInstanceProps,
+  UseGroupByOptions,
+  UseGroupByRowProps,
+  UseGroupByState,
+  UsePaginationInstanceProps,
+  UsePaginationOptions,
+  UsePaginationState,
+  UseResizeColumnsColumnOptions,
+  UseResizeColumnsColumnProps,
+  UseResizeColumnsOptions,
+  UseResizeColumnsState,
+  UseRowSelectHooks,
+  UseRowSelectInstanceProps,
+  UseRowSelectOptions,
+  UseRowSelectRowProps,
+  UseRowSelectState,
+  UseRowStateCellProps,
+  UseRowStateInstanceProps,
+  UseRowStateOptions,
+  UseRowStateRowProps,
+  UseRowStateState,
+  UseSortByColumnOptions,
+  UseTableRowProps,
+  UseSortByColumnProps,
+  UseSortByHooks,
+  UseSortByInstanceProps,
+  UseSortByOptions,
+  UseSortByState,
+} from "react-table";
+
+declare module "react-table" {
+  // take this file as-is, or comment out the sections that don't apply to your plugin configuration
+
+  export interface TableOptions<D extends Record<string, unknown>>
+    extends UseExpandedOptions<D>,
+      UseFiltersOptions<D>,
+      UseGlobalFiltersOptions<D>,
+      UseGroupByOptions<D>,
+      UsePaginationOptions<D>,
+      UseResizeColumnsOptions<D>,
+      UseRowSelectOptions<D>,
+      UseRowStateOptions<D>,
+      UseSortByOptions<D>,
+      // note that having Record here allows you to add anything to the options, this matches the spirit of the
+      // underlying js library, but might be cleaner if it's replaced by a more specific type that matches your
+      // feature set, this is a safe default.
+      Record<string, any> {}
+
+  export interface Hooks<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseExpandedHooks<D>,
+      UseGroupByHooks<D>,
+      UseRowSelectHooks<D>,
+      UseSortByHooks<D> {}
+
+  export interface TableInstance<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseColumnOrderInstanceProps<D>,
+      UseExpandedInstanceProps<D>,
+      UseFiltersInstanceProps<D>,
+      UseGlobalFiltersInstanceProps<D>,
+      UseGroupByInstanceProps<D>,
+      UsePaginationInstanceProps<D>,
+      UseRowSelectInstanceProps<D>,
+      UseRowStateInstanceProps<D>,
+      UseSortByInstanceProps<D> {}
+
+  export interface TableState<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseColumnOrderState<D>,
+      UseExpandedState<D>,
+      UseFiltersState<D>,
+      UseGlobalFiltersState<D>,
+      UseGroupByState<D>,
+      UsePaginationState<D>,
+      UseResizeColumnsState<D>,
+      UseRowSelectState<D>,
+      UseRowStateState<D>,
+      UseSortByState<D> {}
+
+  export interface ColumnInterface<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseFiltersColumnOptions<D>,
+      UseGlobalFiltersColumnOptions<D>,
+      UseGroupByColumnOptions<D>,
+      UseResizeColumnsColumnOptions<D>,
+      UseSortByColumnOptions<D> {}
+
+  export interface ColumnInstance<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseFiltersColumnProps<D>,
+      UseGroupByColumnProps<D>,
+      UseResizeColumnsColumnProps<D>,
+      UseSortByColumnProps<D> {}
+
+  export interface Cell<
+    D extends Record<string, unknown> = Record<string, unknown>,
+    V = any
+  > extends UseGroupByCellProps<D>,
+      UseRowStateCellProps<D> {}
+
+  export interface Row<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseExpandedRowProps<D>,
+      UseGroupByRowProps<D>,
+      UseRowSelectRowProps<D>,
+      UseRowStateRowProps<D>,
+      UseTableRowProps<D> {}
+}


### PR DESCRIPTION
Related to issue #110 

- For fixing the issue with `useTable` hook, i have refered to [React Table Typescript Readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-table/Readme.md)
- In remaining `tsx` files, i have just changed the `let` variable to `const` when it's not being changed.
- In `global.css` file, as the `display:flex` is already added in the style, thus removed the redundant `display: inline-flex`.
- Also testing the basic scenarios by running the app usnig `wails dev` and checking in the linux gui.