### PR TITLE
fix: mysql test connection error (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,16 @@ Install from the Arch User Repository:
 yay -S slashbase
 ```
 
-# Screenshots
-<img src="https://raw.githubusercontent.com/slashbaseide/.github/main/screenshot.png" alt="Run query view" width="100%">
-<img src="https://raw.githubusercontent.com/slashbaseide/.github/main/screenshot2.png" alt="Low-code view" width="100%">
-<img src="https://raw.githubusercontent.com/slashbaseide/.github/main/screenshot3.png" alt="Console view" width="100%">
-
-
-# Slashbase Server
+## Self-host Slashbase Server IDE
 
 To use Slashbase as a self-hosted in-browser collaborative database IDE. See [instructions](https://docs.slashbase.com/docs/server-ide/installation).
 
 To checkout demo, visit [demo.slashbase.com](https://demo.slashbase.com).
+
+# Screenshots
+<img src="https://raw.githubusercontent.com/slashbaseide/.github/main/screenshot.png" alt="Run query view" width="100%">
+<img src="https://raw.githubusercontent.com/slashbaseide/.github/main/screenshot2.png" alt="Low-code view" width="100%">
+<img src="https://raw.githubusercontent.com/slashbaseide/.github/main/screenshot3.png" alt="Console view" width="100%">
 
 # Documentation
 

--- a/frontend/server/src/components/dbfragments/query.tsx
+++ b/frontend/server/src/components/dbfragments/query.tsx
@@ -119,20 +119,22 @@ const DBQueryFragment = () => {
                             queryData={queryData}
                             mSchema={''}
                             mName={''}
-                            onRefresh={()=>{}}
+                            onRefresh={() => { }}
                             onFilterChanged={() => { }}
                             onSortChanged={() => { }}
-                            isInteractive={false} />
+                            isInteractive={false}
+                            isReadOnly={true} />
                     }
                     {dbConnection!.type === DBConnType.MONGO &&
                         <JsonTable
                             dbConnection={dbConnection!}
                             queryData={queryData}
                             mName={''}
-                            onRefresh={()=>{}}
+                            onRefresh={() => { }}
                             onFilterChanged={() => { }}
                             onSortChanged={() => { }}
-                            isInteractive={false} />
+                            isInteractive={false}
+                            isReadOnly={true} />
                     }
                 </React.Fragment>
                 : null

--- a/pkg/queryengines/mysqlqueryengine/queryengine.go
+++ b/pkg/queryengines/mysqlqueryengine/queryengine.go
@@ -87,8 +87,8 @@ func (mqe *MysqlQueryEngine) TestConnection(dbConn *models.DBConnection, config 
 	if err != nil {
 		return err
 	}
-	test := data["rows"].([]map[string]interface{})[0]["0"].(int64)
-	if test == 1 {
+	rows := data["rows"].([]map[string]interface{})
+	if len(rows) != 0 {
 		return nil
 	}
 	return errors.New("connection test failed")


### PR DESCRIPTION
In the file `pkg/queryengines/mysqlqueryengine/queryengine.go`, an error occurred in `MySQL TestConnection`. 

I don't know the exact reason, but it doesn't work while comparing the `test` variable with `1`. 

Since the role of the function in `MySQL TestConnection` is to test the connection, I changed the code to check for the presence or absence of a value rather than validating the exact value. 
